### PR TITLE
Fix erl_scan:token_info deprecated warning

### DIFF
--- a/support/sublimerl_formatter.erl
+++ b/support/sublimerl_formatter.erl
@@ -113,15 +113,14 @@ split_prev_block(Tokens, Line) ->
     {lists:reverse(PrevToks3), NextToks}.
 
 category(Token) ->
-    {category, Cat} = erl_scan:token_info(Token, category),
-    Cat.
+    element(1, Token).
 
 line(Token) ->
-    {line, Line} = erl_scan:token_info(Token, line),
+    {Line, _} = element(2, Token),
     Line.
 
 column(Token) ->
-    {column, Col} = erl_scan:token_info(Token, column),
+    {_, Col} = element(2, Token),
     Col.
 
 indentation_between([], _) ->


### PR DESCRIPTION
Fixing Warning: erl_scan:token_info/2: deprecated (will be removed in OTP 19); use erl_scan:{category,column,line,location,symbol,text}/1 instead